### PR TITLE
[FIX] 마이페이지 API 데이터 매핑 수정 및 유저 로딩 대응

### DIFF
--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -1,15 +1,15 @@
-import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
-import styled from 'styled-components';
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import styled from "styled-components";
 
-import { getMyPosts } from '../api/postApi.index';
-import { useAuthStore } from '../stores/useAuthStore';
+import { getMyPosts } from "../api/postApi.index";
+import { useAuthStore } from "../stores/useAuthStore";
 
-import PrimaryHeader from '../components/header/PrimaryHeader';
-import ProfileSection from '../components/mypage/ProfileSection';
-import StatsSection from '../components/mypage/StatsSection';
-import TabMenu from '../components/mypage/TabMenu';
-import PostItem from '../components/mypage/PostItem';
+import PrimaryHeader from "../components/header/PrimaryHeader";
+import ProfileSection from "../components/mypage/ProfileSection";
+import StatsSection from "../components/mypage/StatsSection";
+import TabMenu from "../components/mypage/TabMenu";
+import PostItem from "../components/mypage/PostItem";
 
 const LayoutContainer = styled.div`
   max-width: 1024px;
@@ -42,37 +42,39 @@ export default function MyPage() {
   const { user } = useAuthStore();
 
   const [posts, setPosts] = useState([]);
-  const [activeTab, setActiveTab] = useState('ALL');
+  const [activeTab, setActiveTab] = useState("ALL");
   const [error, setError] = useState(null);
 
   useEffect(() => {
+    if (!user) return;
+
     const fetchPosts = async () => {
       setError(null);
       try {
         // API 호출
         const data = await getMyPosts(0, 20);
-        setPosts(data.content || []);
+        const rawPosts = data.items || [];
+
+        const mappedPosts = rawPosts.map((post) => ({
+          ...post,
+          postId: post.id,
+        }));
+
+        setPosts(mappedPosts);
       } catch (err) {
         console.error("내 게시글 조회 실패:", err);
         setError("게시글을 불러오는데 실패했습니다.");
       }
     };
+    fetchPosts();
+  }, [user]);
 
-    if (user) {
-       fetchPosts();
-    } else {
-       navigate('/');
-    }
-  }, [user, navigate]);
+  const filteredPosts = activeTab === "ALL" ? posts : posts.filter((post) => post.status === activeTab);
 
-  const filteredPosts = activeTab === 'ALL' 
-    ? posts 
-    : posts.filter(post => post.status === activeTab);
-
-const stats = {
+  const stats = {
     total: posts.length,
-    ongoing: posts.filter(p => p.status === 'OPEN').length,
-    completed: posts.filter(p => p.status === 'COMPLETED').length,
+    ongoing: posts.filter((p) => p.status === "OPEN").length,
+    completed: posts.filter((p) => p.status === "COMPLETED").length,
   };
 
   // 상세 페이지 이동 핸들러
@@ -80,39 +82,25 @@ const stats = {
     navigate(`/post-detail/me/${postId}`);
   };
 
-  const userInfo = user || { nickname: '알 수 없음', email: '' };
+  const userInfo = user || { nickname: "알 수 없음", email: "" };
 
   return (
     <>
       <PrimaryHeader />
-      
+
       <LayoutContainer>
         <ProfileSection nickName={userInfo.nickname} email={userInfo.email} />
         <StatsSection stats={stats} />
 
-        <TabMenu 
-          activeTab={activeTab} 
-          onTabChange={setActiveTab} 
-          stats={stats} 
-        />
+        <TabMenu activeTab={activeTab} onTabChange={setActiveTab} stats={stats} />
         <PostList>
           {error ? (
             <EmptyState>{error}</EmptyState>
           ) : filteredPosts.length > 0 ? (
-            filteredPosts.map(post => (
-              <PostItem 
-                key={post.postId} 
-                post={post} 
-                onClick={handlePostClick} 
-              />
-            ))
+            filteredPosts.map((post) => <PostItem key={post.postId} post={post} onClick={handlePostClick} />)
           ) : (
             <EmptyState>
-              {activeTab === 'ALL' 
-                ? '작성한 게시글이 없습니다.' 
-                : activeTab === 'OPEN' 
-                  ? '진행 중인 리뷰가 없습니다.' 
-                  : '완료된 리뷰가 없습니다.'}
+              {activeTab === "ALL" ? "작성한 게시글이 없습니다." : activeTab === "OPEN" ? "진행 중인 리뷰가 없습니다." : "완료된 리뷰가 없습니다."}
             </EmptyState>
           )}
         </PostList>


### PR DESCRIPTION
## 📣 Related Issue
- close #75 

## 📝 Summary
- **데이터 렌더링 버그 수정**: 서버 응답 데이터의 필드명이 `content`가 아닌 `items`로 내려오는 구조적 차이를 확인하여 매핑 로직을 수정했습니다.
- **데이터 식별자 호환성 확보**: 서버에서 내려주는 `id` 필드를 프론트엔드 컴포넌트 규격인 `postId`로 매핑하여 리스트 렌더링 및 상세 페이지 이동 로직이 정상 작동하도록 조치했습니다.
- **유저 정보 로딩 동기화**: `Zustand Persist`를 통해 새로고침 시 유저 정보가 뒤늦게 복구되면서 API 호출이 누락되던 현상을 `useEffect` 가드 로직(`if (!user) return`) 및 의존성 배열 최적화로 해결했습니다.

## 🖼 스크린샷(UI 변경시)
여기에 게시글 목록이 정상적으로 출력되는 마이페이지 스크린샷을 올려주세요!

## 🙏 Question & PR point

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
