### PR TITLE
[FEAT] 채팅 참여 API 호출 로직

### DIFF
--- a/src/components/chat/ChatSection.jsx
+++ b/src/components/chat/ChatSection.jsx
@@ -6,7 +6,7 @@ import { getChatMessages, joinChatRoom } from "../../api/chat/chatApi.index";
 import { createStompClient } from "../../api/ws/stompClient.index";
 import { useAuthStore } from "../../stores/useAuthStore";
 
-export default function ChatSection({ postId, roomId, selectedLineNumber: externalSelectedLine, onLineClick }) {
+export default function ChatSection({ postId, roomId, selectedLineNumber: externalSelectedLine, onLineClick, isAuthor = false }) {
   const [messages, setMessages] = useState([]);
   const [selectedLineNumber, setSelectedLineNumber] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -96,9 +96,15 @@ export default function ChatSection({ postId, roomId, selectedLineNumber: extern
   }, [roomId]);
 
   const handleSendMessage = (messageText, lineNumber) => {
-    if (!isSocketConnected) {
+    // 작성자가 아닌 경우에만 WebSocket 연결 체크
+    if (!isAuthor && !isSocketConnected) {
       alert("채팅 서버와 연결되어 있지 않습니다.");
       return;
+    }
+
+    // 작성자인 경우에도 WebSocket이 연결되지 않았으면 경고만 표시하고 계속 진행
+    if (isAuthor && !isSocketConnected) {
+      console.warn("[ChatSection] 작성자이지만 WebSocket 연결이 안 되어 있습니다.");
     }
 
     //로그인 체크
@@ -147,10 +153,13 @@ export default function ChatSection({ postId, roomId, selectedLineNumber: extern
     );
   }
 
+  // 작성자인 경우 WebSocket 연결 여부와 관계없이 입력창 활성화
+  const isInputDisabled = isAuthor ? false : !isSocketConnected;
+  
   return (
     <Container>
       <ChatMessageList messages={messages} />
-      <ChatInput onSend={handleSendMessage} selectedLineNumber={selectedLineNumber} onClearSelectedLine={handleClearSelectedLine} disabled={!isSocketConnected}/>
+      <ChatInput onSend={handleSendMessage} selectedLineNumber={selectedLineNumber} onClearSelectedLine={handleClearSelectedLine} disabled={isInputDisabled}/>
     </Container>
   );
 }

--- a/src/components/header/PostDetailHeaderContent.jsx
+++ b/src/components/header/PostDetailHeaderContent.jsx
@@ -5,6 +5,7 @@ import Chip from "../common/Chip/Chip";
 import { formatDate } from "../../utils/formatDate";
 import { useAuthStore } from "../../stores/useAuthStore";
 import { completePost } from "../../api/postApi.index";
+import { joinChatRoom } from "../../api/chat/chatApi.index";
 
 import styled from "styled-components";
 import backIcon from "../../assets/back.svg";
@@ -44,13 +45,28 @@ export default function PostDetailHeaderContent({ post, onPostUpdate }) {
     }
   };
 
+  const handleJoinChatRoom = async () => {
+    if (!post || !post.roomId) {
+      alert("채팅방 정보를 불러올 수 없습니다.");
+      return;
+    }
+
+    try {
+      await joinChatRoom(post.roomId);
+      // console.log("💡 채팅방 참여 성공 - roomId:", post.roomId);
+      // 채팅 섹션으로 스크롤하거나 포커스를 이동할 수 있음
+    } catch (error) {
+      alert("채팅방 참여에 실패했습니다. 다시 시도해주세요.");
+    }
+  };
+
   if (!post) {
     return null;
   }
 
   // 로그인한 사용자가 포스트 작성자인지 확인
-  // const isAuthor = user && post.authorId === user.id;
-  const isAuthor = true;
+  const isAuthor = user && post.authorId === user.id;
+  // const isAuthor = false;
 
   return (
     <Container>
@@ -115,7 +131,7 @@ export default function PostDetailHeaderContent({ post, onPostUpdate }) {
             )
           ) : (
             /* 작성자가 아닐 때: 실시간 연결 버튼 */
-            <Button variant="primary" size="md">
+            <Button variant="primary" size="md" onClick={handleJoinChatRoom}>
               실시간 연결
             </Button>
           )}

--- a/src/pages/PostDetail.jsx
+++ b/src/pages/PostDetail.jsx
@@ -9,6 +9,7 @@ import PostCodeEditor from "../components/post/PostCodeEditor";
 import ChatSection from "../components/chat/ChatSection";
 import Chip from "../components/common/Chip/Chip";
 import usePostCreateStore from "../stores/postCreateStore";
+import { useAuthStore } from "../stores/useAuthStore";
 
 import linkedIcon from "../assets/linked.svg";
 
@@ -20,6 +21,10 @@ export default function PostDetail() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [selectedLineNumber, setSelectedLineNumber] = useState(null);
+  const user = useAuthStore((state) => state.user);
+  
+  // 로그인한 사용자가 포스트 작성자인지 확인
+  const isAuthor = user && post && post.authorId === user.id;
 
   const fetchPost = useCallback(async () => {
     if (!postId) return;
@@ -27,6 +32,7 @@ export default function PostDetail() {
     try {
       setLoading(true);
       const data = await getPost(Number(postId));
+      // console.log("📄 포스트 상세 API 응답:", data);
       setPost(data);
     } catch (err) {
       console.error("포스트 상세 조회 실패:", err);
@@ -111,6 +117,7 @@ export default function PostDetail() {
             roomId={post.roomId}
             selectedLineNumber={selectedLineNumber}
             onLineClick={setSelectedLineNumber}
+            isAuthor={isAuthor}
           />
         </PostSection>
       )}


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
<!-- 아직 완전 해결이 아닌 경우 `partially fixes #번호` 사용 -->
- close #79 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 채팅 참여 API 호출
- 사용자와 작성자가 일치하는 경우 실시간 연결 버튼을 누르지 않아도 채팅 참여 가능  
- 사용자와 작성자가 불일치하는 경우 실시간 연결 버튼을 누른 후에 채팅 참여 가능

